### PR TITLE
Feature/game socket

### DIFF
--- a/batan-client/store/games.js
+++ b/batan-client/store/games.js
@@ -1,5 +1,18 @@
 import Vue from 'vue'
 
+function reviver(key, value) {
+  if (typeof value === 'object' && value !== null) {
+    if (value.dataType === 'Map') {
+      return new Map(value.value)
+    }
+  }
+  return value
+}
+
+function parseJson(str) {
+  return JSON.parse(str, reviver)
+}
+
 export const state = () => ({
   available_games: {},
   active_games: {},
@@ -15,14 +28,16 @@ export const mutations = {
   created(state, game) {
     // Updates available_games by overwriting game
     Vue.set(state.available_games, game.game_id, game);
-    console.log(state.available_games);
   },
   active(state, game) {
+    // TODO: Permit partial updates -- Challenge: potentially complex w/ Vue reactivity
+    game.game_info.board = parseJson(game.game_info.board);
+    // The below line may be needed in case Map in obj is not updated reactively by Vue
+    // game.game_info.board.roadsMap = Object.fromEntries(game.game_info.board.roadsMap);
     Vue.set(state.active_games, game.game_id, game);
     if (state.active_game == '') {
       state.active_game = game;
     }
-    console.log(state.active_games);
   },
   joined(state, game) {
     // courtesy notice, no action taken until game is started
@@ -37,15 +52,5 @@ export const mutations = {
   turnStart(state, data) {
     console.log(data);
   },
-  reviver(key, value) {
-    if (typeof value === 'object' && value !== null) {
-      if (value.dataType === 'Map') {
-        return new Map(value.value)
-      }
-    }
-    return value
-  },
-  parseJson(str) {
-    return JSON.parse(str, this.reviver)
-  }
+
 }

--- a/batan-server/app/api-socket/events/game.ts
+++ b/batan-server/app/api-socket/events/game.ts
@@ -81,10 +81,14 @@ export default (io, socket) => {
   });
 
   socket.on('game/endTurn', (data) => {
-    gameState.playEndTurn(socket.decoded_token.sub,
+    if (!gameState.playEndTurn(socket.decoded_token.sub,
       data.game_id,
-      update_game_clients.bind(null, io, data.game_id, 'game/turnStart'));
-  })
+      update_game_clients.bind(null, io, data.game_id, 'game/turnStart'))) {
+        socket.emit('game/actionFailed', {description: "It's not your turn!"})
+      }
+  });
+
+
 
 
 }

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -217,7 +217,9 @@ export default {
   },
   get_player_info(game_id, player_num) {
     let game = this.games.get(game_id);
+    let player = game.gameObj.players[player_num];
     return {
+      ...player,
       sequence_num: player_num
     }
   },

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -140,13 +140,13 @@ export default {
     */
 
   },
-  playEndTurn(user_id, game_id, end_turn_callback) {
+  playEndTurn(user_id, game_id, callback) {
     /*
     * Player ends their turn (if it is their turn)
     */
     let game = this.games.get(game_id);
     if (game.order[this.whosTurn(game_id)] === user_id) {
-      this.nextTurn(game_id, game.turn_num, end_turn_callback);
+      this.nextTurn(game_id, game.turn_num, callback);
       return true;
     } else {
       return false;
@@ -157,8 +157,6 @@ export default {
     * Sets current turn to next player if turn is expected_turn
     * This allows for turn timeouts to only incremement the turn if they trigger
     * before their turn is ended
-    *
-    * Calls callback with 'next turn' object
     */
     let game = this.games.get(game_id);
     if (game.turn_num === expected_turn) {
@@ -172,10 +170,7 @@ export default {
       }, 180000);
 
       game.end_turn_time = end_turn_time.toISOString();
-
-      let turnStartData = this.get_full_game_info(game_id);
-
-      callback(turnStartData);
+      callback();
     }
   },
   get_full_game_info(game_id){
@@ -219,6 +214,12 @@ export default {
       turnStartData.turn.type = "init";
     }
     return turnStartData;
+  },
+  get_player_info(game_id, player_num) {
+    let game = this.games.get(game_id);
+    return {
+      sequence_num: player_num
+    }
   },
   whosTurn(game_id) {
     /*

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -144,9 +144,9 @@ export default {
     let game = this.games.get(game_id);
     if (game.order[this.whosTurn(game_id)] === user_id) {
       this.nextTurn(game_id, game.turn_num, end_turn_callback);
-      console.log("Ended turn!");
+      return true;
     } else {
-      console.log("Not your turn!");
+      return false;
     }
   },
   nextTurn(game_id, expected_turn, callback) {

--- a/batan-server/engine/game.ts
+++ b/batan-server/engine/game.ts
@@ -752,7 +752,7 @@ export default class Game {
     }
   }
 
-  private replacer(this: any, key: any, value: any) {
+  replacer(this: any, key: any, value: any) {
     const obj = this[key];
     if (obj instanceof Map) {
       return {


### PR DESCRIPTION
Update client with game state for games they're part of.
Should work with multiple tabs open of same player; 2-4 players

network heavy (sends full update every time) but this avoids some complications with reactivity in vue on vuex side.

Note: 
- Maps aren't reactive in vue 2, but board road map is inside object, so reactivity may trigger when object is updated. 

Clients should only have access to public information & their personal info (for each game).. if that's not the case, this is broken!