### PR TITLE
Feature/game socket

### DIFF
--- a/batan-client/pages/test_sockets.vue
+++ b/batan-client/pages/test_sockets.vue
@@ -87,6 +87,18 @@
         </b-form-checkbox>
       </b-col>
     </b-row>
+    <b-row>
+      <b-col sm="2">
+        <label>Boot player #</label>
+      </b-col>
+      <b-col sm="2">
+        <b-form-input :type="`number`" v-model="toboot_alias"></b-form-input>
+      </b-col>
+      <b-col sm="2">
+        <b-button @click.prevent="boot_player()" size="md" variant="dark">boot</b-button>
+      </b-col>
+    </b-row>
+
   </div>
 
   <br>  <br>
@@ -151,7 +163,8 @@ export default Vue.extend({
       cheat_ore: 5,
       cheat_brick: 5,
       timeout_s: 10,
-      skip_offline: false
+      skip_offline: false,
+      toboot_alias: 2
     }
   },
   created() {
@@ -165,6 +178,12 @@ export default Vue.extend({
     }
   },
   methods: {
+    boot_player() {
+      this.$root.socket.emit('game/admin/boot', {
+        game_id: this.game_id,
+        bootee: Number(this.toboot_alias)
+      });
+    },
     set_timeout_length() {
       this.$root.socket.emit('game/admin/settimeout', {
         game_id: this.game_id,

--- a/batan-client/pages/test_sockets.vue
+++ b/batan-client/pages/test_sockets.vue
@@ -67,10 +67,24 @@
   <br>  <br>
   <b-button @click.prevent="endTurn()" size="md" variant="dark">end turn</b-button>
   <br>  <br>
+  <div class="">
+    <h3>Admin</h3>
+    <b-row>
+      <b-col sm="4">
+        <label>timeout (seconds)</label>
+      </b-col>
+      <b-col sm="2">
+        <b-form-input :type="`number`" v-model="timeout_s"></b-form-input>
+      </b-col>
+      <b-col sm="2">
+        <b-button @click.prevent="set_timeout_length()" size="md" variant="dark">set timeout</b-button>
+      </b-col>
+    </b-row>
+  </div>
 
   <br>  <br>
-  <h3>Cheat Menu (acquire cards) <b-button @click.prevent="cheat_cards()" size="md" variant="dark">Get Cards</b-button></h3>
   <div class="">
+    <h3>Cheat Menu (acquire cards) <b-button @click.prevent="cheat_cards()" size="md" variant="dark">Get Cards</b-button></h3>
     <b-row>
       <b-col sm="2">
         <label>sheep</label>
@@ -129,11 +143,18 @@ export default Vue.extend({
       cheat_wood: 5,
       cheat_ore: 5,
       cheat_brick: 5,
+      timeout_s: 10
     }
   },
   created() {
   },
   methods: {
+    set_timeout_length() {
+      this.$root.socket.emit('game/admin/settimeout', {
+        game_id: this.game_id,
+        timeout: this.timeout_s
+      });
+    },
     moveRobber() {
       this.$root.socket.emit('game/moveRobber', {
         game_id: this.game_id,

--- a/batan-client/pages/test_sockets.vue
+++ b/batan-client/pages/test_sockets.vue
@@ -80,6 +80,13 @@
         <b-button @click.prevent="set_timeout_length()" size="md" variant="dark">set timeout</b-button>
       </b-col>
     </b-row>
+    <b-row>
+      <b-col sm="4">
+        <b-form-checkbox v-model="skip_offline" name="check-button" switch>
+          Skip offline players
+        </b-form-checkbox>
+      </b-col>
+    </b-row>
   </div>
 
   <br>  <br>
@@ -143,10 +150,19 @@ export default Vue.extend({
       cheat_wood: 5,
       cheat_ore: 5,
       cheat_brick: 5,
-      timeout_s: 10
+      timeout_s: 10,
+      skip_offline: false
     }
   },
   created() {
+  },
+  watch: {
+    skip_offline() {
+      this.$root.socket.emit('game/admin/setSkipIfOffline', {
+        game_id: this.game_id,
+        skip: this.skip_offline
+      });
+    }
   },
   methods: {
     set_timeout_length() {

--- a/batan-server/app/api-socket/events/game.ts
+++ b/batan-server/app/api-socket/events/game.ts
@@ -248,6 +248,19 @@ export default (io, socket) => {
     }
   });
 
+  socket.on('game/admin/boot', (data) => {
+    if (gameState.adminBootPlayer(socket.decoded_token.sub, data.game_id, data.bootee)) {
+      if (gameState.games.get(data.game_id).started) {
+        send_active_game(io, data.game_id);   // in case game is started already
+      } else {
+        send_created_game(io, data.game_id);  // in case game not started
+      }
+      socket.emit('game/admin/player_booted');
+    } else {
+      socket.emit('game/actionFailed', {description: "Booting player failed"});
+    }
+  })
+
   // TODO: Wrap in env flag -- only available in dev
   socket.on('game/cheat', (data) => {
     if (gameState.cheat_get_cards(socket.decoded_token.sub, data.game_id, data.cards)) {

--- a/batan-server/app/api-socket/events/game.ts
+++ b/batan-server/app/api-socket/events/game.ts
@@ -234,7 +234,7 @@ export default (io, socket) => {
 
   socket.on('game/admin/settimeout', (data) => {
     if (gameState.adminSetTimeout(socket.decoded_token.sub, data.game_id, data.timeout)) {
-      socket.emit('game/admin/timeout_set');
+      send_active_game(io, data.game_id);
     } else {
       socket.emit('game/actionFailed', {description: "Setting timeout failed"});
     }
@@ -242,7 +242,7 @@ export default (io, socket) => {
 
   socket.on('game/admin/setSkipIfOffline', (data) => {
     if (gameState.adminSetSkipDC(socket.decoded_token.sub, data.game_id, data.skip)) {
-      socket.emit('game/admin/skip_offline_set');
+      send_active_game(io, data.game_id);
     } else {
       socket.emit('game/actionFailed', {description: "Setting skip offline players failed"});
     }
@@ -255,7 +255,7 @@ export default (io, socket) => {
       } else {
         send_created_game(io, data.game_id);  // in case game not started
       }
-      socket.emit('game/admin/player_booted');
+      // socket.emit('game/admin/player_booted');
     } else {
       socket.emit('game/actionFailed', {description: "Booting player failed"});
     }

--- a/batan-server/app/api-socket/events/game.ts
+++ b/batan-server/app/api-socket/events/game.ts
@@ -240,6 +240,13 @@ export default (io, socket) => {
     }
   });
 
+  socket.on('game/admin/setSkipIfOffline', (data) => {
+    if (gameState.adminSetSkipDC(socket.decoded_token.sub, data.game_id, data.skip)) {
+      socket.emit('game/admin/skip_offline_set');
+    } else {
+      socket.emit('game/actionFailed', {description: "Setting skip offline players failed"});
+    }
+  });
 
   // TODO: Wrap in env flag -- only available in dev
   socket.on('game/cheat', (data) => {

--- a/batan-server/app/api-socket/events/game.ts
+++ b/batan-server/app/api-socket/events/game.ts
@@ -232,6 +232,15 @@ export default (io, socket) => {
       }
   });
 
+  socket.on('game/admin/settimeout', (data) => {
+    if (gameState.adminSetTimeout(socket.decoded_token.sub, data.game_id, data.timeout)) {
+      socket.emit('game/admin/timeout_set');
+    } else {
+      socket.emit('game/actionFailed', {description: "Setting timeout failed"});
+    }
+  });
+
+
   // TODO: Wrap in env flag -- only available in dev
   socket.on('game/cheat', (data) => {
     if (gameState.cheat_get_cards(socket.decoded_token.sub, data.game_id, data.cards)) {

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -18,6 +18,7 @@ export default {
       game_name: game_name,
       game_owner: user_id,
       started: false,
+      turn_timeout_length: 180000,
       turn_num: -1,
       turn_phase: "roll",
       dice: 0,
@@ -71,6 +72,22 @@ export default {
     } else {
       return false; // game does not exist
     }
+  },
+  adminSetTimeout(user_id, game_id, timeout_s) {
+    /*
+    * Set timeout to timeout_s (seconds)
+    */
+    if (!this.games.has(game_id)) {
+      return false;
+    }
+    let game = this.games.get(game_id);
+    if (game.game_owner === user_id) {
+      game.turn_timeout_length = timeout_s * 1000;
+      return true;
+    } else {
+      console.log("You are not owner of this game");
+    }
+    return false;
   },
   adminBootPlayer(user_id, game_id, playerIdToBoot) {
     /*
@@ -438,7 +455,7 @@ export default {
       let curr_turn = game.turn_num;
       setTimeout(() => {
         this.nextTurn(game_id, curr_turn, callback);
-      }, 180000);
+      }, game.turn_timeout_length);
 
       game.end_turn_time = end_turn_time.toISOString();
       callback();

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -435,9 +435,9 @@ export default {
 
       let end_turn_time = new Date();
       end_turn_time.setSeconds(end_turn_time.getSeconds() + 180)
-
+      let curr_turn = game.turn_num;
       setTimeout(() => {
-        this.nextTurn(game_id, game.turn_num, callback);
+        this.nextTurn(game_id, curr_turn, callback);
       }, 180000);
 
       game.end_turn_time = end_turn_time.toISOString();

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -90,10 +90,34 @@ export default {
     }
     return false;
   },
-  adminBootPlayer(user_id, game_id, playerIdToBoot) {
+  adminBootPlayer(user_id, game_id, bootee) {
     /*
-    * Remove a player from unstarted game, or set to skip their turn if game started
+    * Boot player from game (before or after start, but slightly different behaviour)
     */
+    if (!this.games.has(game_id)) {
+      return false;
+    }
+    let game = this.games.get(game_id);
+    if (game.game_owner === user_id && game.id.id_sub.has(bootee)) {
+
+      if (!game.started) {
+        let bootee_sub = game.id.id_sub.get(bootee);
+        game.players.delete(bootee_sub);
+        if (this.players.has(user_id)){
+          this.players.get(user_id).splice(this.players.get(user_id).indexOf(game.game_id), 1);
+        }
+        game.id.id_sub.delete(bootee);
+        game.id.sub_id.delete(bootee_sub);
+      } else {
+        // TODO: -- Need to verify many other things for this..
+        return false;
+      }
+
+      return true;
+    } else {
+      console.log("You are not owner of this game");
+    }
+    return false;
 
   },
   adminSetSkipDC(user_id, game_id, skip_disconnected_players: boolean) {

--- a/batan-server/app/state/game.ts
+++ b/batan-server/app/state/game.ts
@@ -540,6 +540,10 @@ export default {
     let dc = game.gameObj.bank.developmentCards;
     let turnStartData = {
       game_id: game_id,
+      settings: {
+        turn_timeout_length: game.turn_timeout_length,
+        skip_offline_players: game.skip_if_dc
+      },
       turn: {
         type: "normal",
         player: this.whosTurn(game_id) + 1,


### PR DESCRIPTION
! Bug Fix: turn timeouts from previous turns causing current turn to end prematurely/ randomly

Implement admin/ game owner features
- change game settings (turn timeout length, skip turns of offline players) 
- boot players (pre-game only.. probably won't get to booting in-game)

